### PR TITLE
return authData so we can grab both the access-token and refresh-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ var moves = new movesApi({
     "clientSecret": "ClientSecret",
     "redirectUri": "RedirectUri",
     "accessToken": "",
+    "refreshToken" : "",
 });
 
 // Redirect your user to this url
 var url = moves.generateAuthUrl();
 
-moves.getAccessToken(code_from_redirect, function(err, accessToken) {
-    moves.options.accessToken = accessToken;
+moves.getAccessToken(code_from_redirect, function(err, authData) {
+    moves.options.accessToken = authData.accessToken;
 
     moves.getProfile(function(err, profile) {
         console.log(profile);

--- a/lib/MovesApi.js
+++ b/lib/MovesApi.js
@@ -9,7 +9,8 @@ function MovesApi(options) {
         clientId: '',
         clientSecret: '',
         redirectUri: '',
-        accessToken: ''
+        accessToken: '',
+        refreshToken: '',
     };
 }
 
@@ -44,12 +45,12 @@ MovesApi.prototype.getAccessToken = function getAccessToken(code, cb) {
 
             function(error, response, body) {
                 body = convertResponse(body);
-
+                this.options.refreshToken = body.refresh_token;
                 if(handleError(error, body, cb)) {
                     return;
                 }
 
-                cb(null, body.access_token);
+                cb(null, body);
     });
 };
 


### PR DESCRIPTION
This way we're able to query moves api without the user having to re-authenticate, if we store the refresh token in a db.
