### PR TITLE
Fixed scope error.

### DIFF
--- a/lib/MovesApi.js
+++ b/lib/MovesApi.js
@@ -51,7 +51,8 @@ MovesApi.prototype.getAccessToken = function getAccessToken(code, cb) {
                 }
 
                 cb(null, body);
-    });
+            }.bind(this)
+    );
 };
 
 MovesApi.prototype.verifyToken = function verifyToken(cb) {


### PR DESCRIPTION
`this.options.refreshToken` was not in scope. The `this` inside request.post belongs to request.
