### PR TITLE
Add support for handling Rate Limiting Errors

### DIFF
--- a/lib/MovesApi.js
+++ b/lib/MovesApi.js
@@ -46,7 +46,7 @@ MovesApi.prototype.getAccessToken = function getAccessToken(code, cb) {
             function(error, response, body) {
                 body = convertResponse(body);
                 this.options.refreshToken = body.refresh_token;
-                if(handleError(error, body, cb)) {
+                if(handleError(error, response, body, cb)) {
                     return;
                 }
 
@@ -64,7 +64,7 @@ MovesApi.prototype.verifyToken = function verifyToken(cb) {
         function(error, response, body) {
             body = convertResponse(body);
 
-            if(handleError(error, body, cb)) {
+            if(handleError(error, response, body, cb)) {
                 return;
             }
 
@@ -85,7 +85,7 @@ MovesApi.prototype.refreshToken = function refreshToken(cb) {
         function(error, response, body) {
             body = convertResponse(body);
             
-            if(handleError(error, body, cb)) {
+            if(handleError(error, response, body, cb)) {
                 return;
             }
 
@@ -104,7 +104,7 @@ MovesApi.prototype.getProfile = function getProfile(cb) {
         function(error, response, body) {
             body = convertResponse(body);
 
-            if(handleError(error, body, cb)) {
+            if(handleError(error, response, body, cb)) {
                 return;
             }
 
@@ -125,7 +125,7 @@ MovesApi.prototype.getSummaries = function getSummaries(options, cb) {
         function(error, response, body) {
             body = convertResponse(body);
 
-            if(handleError(error, body, cb)) {
+            if(handleError(error, response, body, cb)) {
                 return;
             }
 
@@ -146,7 +146,7 @@ MovesApi.prototype.getActivities = function getActivities(options, cb) {
         function(error, response, body) {
             body = convertResponse(body);
 
-            if(handleError(error, body, cb)) {
+            if(handleError(error, response, body, cb)) {
                 return;
             }
 
@@ -167,7 +167,7 @@ MovesApi.prototype.getPlaces = function getPlaces(options, cb) {
         function(error, response, body) {
             body = convertResponse(body);
 
-            if(handleError(error, body, cb)) {
+            if(handleError(error, response, body, cb)) {
                 return;
             }
 
@@ -188,7 +188,7 @@ MovesApi.prototype.getStoryline = function getStoryline(options, cb) {
         function(error, response, body) {
             body = convertResponse(body);
 
-            if(handleError(error, body, cb)) {
+            if(handleError(error, response, body, cb)) {
                 return;
             }
 
@@ -207,7 +207,7 @@ MovesApi.prototype.getActivitiesList = function getActivitiesList(cb) {
         function(error, response, body) {
             body = convertResponse(body);
 
-            if(handleError(error, body, cb)) {
+            if(handleError(error, response, body, cb)) {
                 return;
             }
 
@@ -270,7 +270,7 @@ var urlStructure = function(url, options, access_token) {
     return url;
 };
 
-var handleError = function handleError(error, body, cb) {
+var handleError = function handleError(error, response, body, cb) {
     if(error) {
         cb(error);
         return true;
@@ -279,6 +279,11 @@ var handleError = function handleError(error, body, cb) {
     if(body.error) {
         cb(body.error);
         return true;
+    }
+
+    if(response.statusCode === 429){
+      cb(new Error("Moves API Rate Limit Exceeded"))
+      return true;
     }
 
     return false;


### PR DESCRIPTION
When requests are received with status code 429, the request has failed due to rate limiting. This commit adds support for returning an error in this case.
